### PR TITLE
Do not validate TermsOfUse against non-existing schema

### DIFF
--- a/rest/src/main/java/org/envirocar/server/rest/Schemas.java
+++ b/rest/src/main/java/org/envirocar/server/rest/Schemas.java
@@ -58,8 +58,8 @@ public class Schemas {
     public static final String STATISTIC = PREFIX + "statistic.json#";
     public static final String ACTIVITY = PREFIX + "activitiy.json#";
     public static final String ACTIVITIES = PREFIX + "activities.json#";
-	public static final String TERMS_OF_USE = PREFIX + "terms-of-use.json#";
-	public static final String TERMS_OF_USE_INSTANCE = PREFIX + "terms-of-use-instance.json#";
+    public static final String TERMS_OF_USE = PREFIX + "terms-of-use.json#";
+    public static final String TERMS_OF_USE_INSTANCE = PREFIX + "terms-of-use-instance.json#";
 
     private Schemas() {
     }

--- a/rest/src/main/java/org/envirocar/server/rest/resources/TermsOfUseInstanceResource.java
+++ b/rest/src/main/java/org/envirocar/server/rest/resources/TermsOfUseInstanceResource.java
@@ -22,8 +22,6 @@ import javax.ws.rs.Produces;
 import org.envirocar.server.core.entities.TermsOfUseInstance;
 import org.envirocar.server.core.exception.TrackNotFoundException;
 import org.envirocar.server.rest.MediaTypes;
-import org.envirocar.server.rest.Schemas;
-import org.envirocar.server.rest.validation.Schema;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -33,9 +31,7 @@ import com.google.inject.assistedinject.Assisted;
  *
  */
 public class TermsOfUseInstanceResource extends AbstractResource {
-
-
-    private TermsOfUseInstance termsOfUseInstance;
+    private final TermsOfUseInstance termsOfUseInstance;
 
 	@Inject
     public TermsOfUseInstanceResource(@Assisted TermsOfUseInstance t) {
@@ -43,7 +39,8 @@ public class TermsOfUseInstanceResource extends AbstractResource {
     }
 	
     @GET
-    @Schema(response = Schemas.TERMS_OF_USE_INSTANCE)
+    //FIXME create a schema for terms of use instance
+    //@Schema(response = Schemas.TERMS_OF_USE_INSTANCE)
     @Produces({ MediaTypes.TERMS_OF_USE_INSTANCE })
     public TermsOfUseInstance get() throws TrackNotFoundException {
         return termsOfUseInstance;

--- a/rest/src/main/java/org/envirocar/server/rest/resources/TermsOfUseResource.java
+++ b/rest/src/main/java/org/envirocar/server/rest/resources/TermsOfUseResource.java
@@ -29,15 +29,14 @@ import org.envirocar.server.core.exception.ResourceNotFoundException;
 import org.envirocar.server.core.util.Pagination;
 import org.envirocar.server.rest.MediaTypes;
 import org.envirocar.server.rest.RESTConstants;
-import org.envirocar.server.rest.Schemas;
-import org.envirocar.server.rest.validation.Schema;
 
 public class TermsOfUseResource extends AbstractResource {
 
     public static final String TERMS_OF_USE_INSTANCE = "{termsOfUse}";
 
 	@GET
-    @Schema(response = Schemas.TERMS_OF_USE)
+    //FIXME create a schema for terms of use
+    //@Schema(response = Schemas.TERMS_OF_USE)
     @Produces({ MediaTypes.TERMS_OF_USE })
     public TermsOfUse get(
             @QueryParam(RESTConstants.LIMIT) @DefaultValue("0") int limit,


### PR DESCRIPTION
Will fix the ISE at https://giv-car.uni-muenster.de/dev/rest/termsOfUse introduced by #132. The server tries to validate the terms of use against a schema that doesn't exist yet.
