### PR TITLE
Enable file extension based content negotiation

### DIFF
--- a/rest/src/main/java/org/envirocar/server/rest/URIContentNegotiationFilter.java
+++ b/rest/src/main/java/org/envirocar/server/rest/URIContentNegotiationFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2013 The enviroCar project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.envirocar.server.rest;
+
+import javax.ws.rs.core.MediaType;
+
+import com.google.common.collect.ImmutableMap;
+import com.sun.jersey.api.container.filter.UriConnegFilter;
+
+public class URIContentNegotiationFilter extends UriConnegFilter {
+
+    public URIContentNegotiationFilter() {
+        super(ImmutableMap.<String, MediaType>builder()
+                .put("json", MediaType.APPLICATION_JSON_TYPE)
+                .put("ttl", MediaTypes.TURTLE_TYPE)
+                .put("rdf", MediaTypes.XML_RDF_TYPE)
+                .build());
+    }
+
+}

--- a/rest/src/main/java/org/envirocar/server/rest/guice/JerseyModule.java
+++ b/rest/src/main/java/org/envirocar/server/rest/guice/JerseyModule.java
@@ -19,6 +19,7 @@ package org.envirocar.server.rest.guice;
 import java.util.Map;
 
 import org.envirocar.server.rest.PaginationFilter;
+import org.envirocar.server.rest.URIContentNegotiationFilter;
 import org.envirocar.server.rest.auth.AuthenticationFilter;
 import org.envirocar.server.rest.auth.AuthenticationResourceFilterFactory;
 import org.envirocar.server.rest.validation.JSONSchemaResourceFilterFactory;
@@ -42,9 +43,6 @@ import com.sun.jersey.spi.container.ResourceFilterFactory;
  * @author Christian Autermann <autermann@uni-muenster.de>
  */
 public class JerseyModule extends JerseyServletModule {
-    private static final String TRUE = String.valueOf(true);
-    private static final String FALSE = String.valueOf(false);
-
     @Override
     protected void configureServlets() {
         serve("/*").with(GuiceContainer.class, getContainerFilterConfig());
@@ -66,14 +64,18 @@ public class JerseyModule extends JerseyServletModule {
     }
 
     protected ImmutableList<Class<? extends ContainerResponseFilter>> responseFilters() {
-        return ImmutableList.of(PaginationFilter.class, GZIPContentEncodingFilter.class);
+        return ImmutableList.of(PaginationFilter.class,
+                                GZIPContentEncodingFilter.class);
     }
 
     protected ImmutableList<Class<? extends ContainerRequestFilter>> requestFilters() {
-        return ImmutableList.of(GZIPContentEncodingFilter.class, AuthenticationFilter.class);
+        return ImmutableList.of(GZIPContentEncodingFilter.class,
+                                URIContentNegotiationFilter.class,
+                                AuthenticationFilter.class);
     }
 
     protected ImmutableList<Class<? extends ResourceFilterFactory>> filterFactories() {
-        return ImmutableList.of(AuthenticationResourceFilterFactory.class, JSONSchemaResourceFilterFactory.class);
+        return ImmutableList.of(AuthenticationResourceFilterFactory.class,
+                                JSONSchemaResourceFilterFactory.class);
     }
 }


### PR DESCRIPTION
Currently only with `ttl`, `rdf` and `json` extensions. I think this will fix #148 in  a way more convenient way than `javax.servlet.Filter`s or changing every single resource…
