### PR TITLE
Expose Link header with Access-Control-Expose-Headers

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
         </init-param>
         <init-param>
             <param-name>cors.exposedHeaders</param-name>
-            <param-value>Content-Type, Content-Encoding</param-value>
+            <param-value>Content-Type, Content-Encoding, Link</param-value>
         </init-param>
     </filter>
     <filter-mapping>


### PR DESCRIPTION
Currently JavaScript clients are not allowed to read the `Link` header (reported by Benedikt Klus).
