### PR TITLE
Feature/decode context knowledge

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,11 +17,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <scope>test</scope>
+        </dependency>
         <dependency>
             <artifactId>slf4j-api</artifactId>
             <groupId>org.slf4j</groupId>

--- a/event/src/main/java/org/envirocar/server/event/HTTPPushListener.java
+++ b/event/src/main/java/org/envirocar/server/event/HTTPPushListener.java
@@ -74,7 +74,7 @@ public class HTTPPushListener {
                     .encodeJSON(track, DEFAULT_ACCESS_RIGHTS,
                                 MediaTypes.TRACK_TYPE);
             String content = writer.writeValueAsString(jsonTrack);
-            logger.debug("Entity: {}", content);
+            //logger.debug("Entity: {}", content);
             HttpEntity entity = new StringEntity(
                     content, ContentType.create(MediaTypes.TRACK));
             HttpPost hp = new HttpPost(host);

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>hamcrest-all</artifactId>
         </dependency>
         <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/AbstractJSONMessageBodyReader.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/AbstractJSONMessageBodyReader.java
@@ -80,7 +80,7 @@ public abstract class AbstractJSONMessageBodyReader<T>
         }
     }
 
-    public T decode(JsonNode j, MediaType mt, ContextKnowledge<T> knowledge) {
+    public T decode(JsonNode j, MediaType mt, ContextKnowledge knowledge) {
         return decode(j, mt);
     };
     

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/AbstractJSONMessageBodyReader.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/AbstractJSONMessageBodyReader.java
@@ -80,5 +80,9 @@ public abstract class AbstractJSONMessageBodyReader<T>
         }
     }
 
+    public T decode(JsonNode j, MediaType mt, ContextKnowledge<T> knowledge) {
+        return decode(j, mt);
+    };
+    
     public abstract T decode(JsonNode j, MediaType mt);
 }

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/ContextKnowledge.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/ContextKnowledge.java
@@ -16,16 +16,20 @@
  */
 package org.envirocar.server.rest.decoding.json;
 
-import javax.ws.rs.core.MediaType;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * TODO JavaDoc
  *
- * @author Christian Autermann <autermann@uni-muenster.de>
  */
-public interface JSONEntityDecoder<T> {
-    T decode(JsonNode j, MediaType mt);
-    T decode(JsonNode j, MediaType mt, ContextKnowledge<T> knowledge);
+public class ContextKnowledge<T> {
+    
+    private final T object;
+
+    public ContextKnowledge(T obj) {
+        this.object = obj;
+    }
+
+    public T get() {
+        return this.object;
+    }
+
 }

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/ContextKnowledge.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/ContextKnowledge.java
@@ -16,20 +16,13 @@
  */
 package org.envirocar.server.rest.decoding.json;
 
+import java.util.HashMap;
+
 
 /**
  *
  */
-public class ContextKnowledge<T> {
+public class ContextKnowledge extends HashMap<String, Object> {
     
-    private final T object;
-
-    public ContextKnowledge(T obj) {
-        this.object = obj;
-    }
-
-    public T get() {
-        return this.object;
-    }
 
 }

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/ContextKnowledgeFactory.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/ContextKnowledgeFactory.java
@@ -16,11 +16,14 @@
  */
 package org.envirocar.server.rest.decoding.json;
 
-import java.util.HashMap;
 
 /**
  *
  */
-public class ContextKnowledge extends HashMap<String, Object> {
+public class ContextKnowledgeFactory {
+    
+    public ContextKnowledge create() {
+        return new ContextKnowledge();
+    }
 
 }

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/JSONEntityDecoder.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/JSONEntityDecoder.java
@@ -27,5 +27,5 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public interface JSONEntityDecoder<T> {
     T decode(JsonNode j, MediaType mt);
-    T decode(JsonNode j, MediaType mt, ContextKnowledge<T> knowledge);
+    T decode(JsonNode j, MediaType mt, ContextKnowledge knowledge);
 }

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/MeasurementDecoder.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/MeasurementDecoder.java
@@ -25,9 +25,7 @@ import javax.ws.rs.ext.Provider;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import com.vividsolutions.jts.geom.Geometry;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.envirocar.server.core.dao.PhenomenonDao;

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/TrackDecoder.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/TrackDecoder.java
@@ -78,7 +78,7 @@ public class TrackDecoder extends AbstractJSONEntityDecoder<Track> {
             JsonNode ms = j.path(GeoJSONConstants.FEATURES_KEY);
             TrackWithMeasurments twm = new TrackWithMeasurments(track);
             
-            ContextKnowledge<Measurement> knowledge = null;
+            ContextKnowledge knowledge = new ContextKnowledge();
             
             for (int i = 0; i < ms.size(); i++) {
                 Measurement m = measurementDecoder.decode(ms.get(i), mediaType, knowledge);
@@ -87,10 +87,6 @@ public class TrackDecoder extends AbstractJSONEntityDecoder<Track> {
                     m.setSensor(trackSensor);
                 }
                 twm.addMeasurement(m);
-                
-                if (knowledge == null) {
-                    knowledge = new ContextKnowledge<>(m);
-                }
                 
             }
             track = twm;

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/TrackDecoder.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/TrackDecoder.java
@@ -40,14 +40,16 @@ import com.google.inject.Inject;
 public class TrackDecoder extends AbstractJSONEntityDecoder<Track> {
     private final JSONEntityDecoder<Measurement> measurementDecoder;
     private final SensorDao sensorDao;
+    private final ContextKnowledgeFactory contextKnowledgeFactory;
 
     @Inject
     public TrackDecoder(JSONEntityDecoder<Measurement> measurementDecoder,
                         SensorDao sensorDao,
-                        MeasurementDao measurementDao) {
+                        MeasurementDao measurementDao, ContextKnowledgeFactory ckFac) {
         super(Track.class);
         this.measurementDecoder = measurementDecoder;
         this.sensorDao = sensorDao;
+        this.contextKnowledgeFactory = ckFac;
     }
 
     @Override
@@ -78,7 +80,7 @@ public class TrackDecoder extends AbstractJSONEntityDecoder<Track> {
             JsonNode ms = j.path(GeoJSONConstants.FEATURES_KEY);
             TrackWithMeasurments twm = new TrackWithMeasurments(track);
             
-            ContextKnowledge knowledge = new ContextKnowledge();
+            ContextKnowledge knowledge = contextKnowledgeFactory.create();
             
             for (int i = 0; i < ms.size(); i++) {
                 Measurement m = measurementDecoder.decode(ms.get(i), mediaType, knowledge);

--- a/rest/src/main/java/org/envirocar/server/rest/decoding/json/TrackDecoder.java
+++ b/rest/src/main/java/org/envirocar/server/rest/decoding/json/TrackDecoder.java
@@ -77,13 +77,21 @@ public class TrackDecoder extends AbstractJSONEntityDecoder<Track> {
         if (!j.path(GeoJSONConstants.FEATURES_KEY).isMissingNode()) {
             JsonNode ms = j.path(GeoJSONConstants.FEATURES_KEY);
             TrackWithMeasurments twm = new TrackWithMeasurments(track);
+            
+            ContextKnowledge<Measurement> knowledge = null;
+            
             for (int i = 0; i < ms.size(); i++) {
-                Measurement m = measurementDecoder.decode(ms.get(i), mediaType);
+                Measurement m = measurementDecoder.decode(ms.get(i), mediaType, knowledge);
                 m.setTrack(track);
                 if (m.getSensor() == null) {
                     m.setSensor(trackSensor);
                 }
                 twm.addMeasurement(m);
+                
+                if (knowledge == null) {
+                    knowledge = new ContextKnowledge<>(m);
+                }
+                
             }
             track = twm;
         }

--- a/rest/src/main/java/org/envirocar/server/rest/guice/JerseyDecoderModule.java
+++ b/rest/src/main/java/org/envirocar/server/rest/guice/JerseyDecoderModule.java
@@ -41,6 +41,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.vividsolutions.jts.geom.Geometry;
+import org.envirocar.server.rest.decoding.json.ContextKnowledgeFactory;
+import org.opengis.geometry.coordinate.Cone;
 
 /**
  * TODO JavaDoc
@@ -79,5 +81,6 @@ public class JerseyDecoderModule extends AbstractModule {
         bind(FuelingDecoder.class).in(Scopes.SINGLETON);
         bind(new TypeLiteral<JSONEntityDecoder<Fueling>>() {
         }).to(FuelingDecoder.class);
+        bind(ContextKnowledgeFactory.class).toInstance(new ContextKnowledgeFactory());
     }
 }

--- a/rest/src/test/java/org/envirocar/server/rest/decoding/json/ContextKnowledgeTest.java
+++ b/rest/src/test/java/org/envirocar/server/rest/decoding/json/ContextKnowledgeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2013 The enviroCar project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.envirocar.server.rest.decoding.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.ws.rs.core.MediaType;
+import org.envirocar.server.core.dao.MeasurementDao;
+import org.envirocar.server.core.dao.PhenomenonDao;
+import org.envirocar.server.core.dao.SensorDao;
+import org.envirocar.server.core.entities.EntityFactory;
+import org.envirocar.server.core.entities.Measurement;
+import org.envirocar.server.core.entities.MeasurementValue;
+import org.envirocar.server.core.entities.Phenomenon;
+import org.envirocar.server.core.entities.Track;
+import org.envirocar.server.rest.JSONConstants;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ *
+ */
+public class ContextKnowledgeTest {
+    private SensorDao sensorDao;
+    private MeasurementDao measurementsDao;
+    private PhenomenonDao phenonmenonDao;
+    private EntityFactory ef;
+    private DateTimeFormatter dtf;
+    private ContextKnowledgeFactory ckf;
+    private ContextKnowledge context;
+    
+    @Before
+    public void initMocks() {
+        this.ef = Mockito.mock(EntityFactory.class);
+        Mockito.when(ef.createTrack()).thenReturn(Mockito.mock(Track.class));
+        Mockito.when(ef.createMeasurement()).thenReturn(Mockito.mock(Measurement.class));
+        Mockito.when(ef.createMeasurementValue()).thenReturn(Mockito.mock(MeasurementValue.class));
+        Mockito.when(ef.createPhenomenon()).thenReturn(Mockito.mock(Phenomenon.class));
+
+        this.dtf = ISODateTimeFormat.dateTimeNoMillis();
+        
+        this.ckf = Mockito.mock(ContextKnowledgeFactory.class);
+        this.context = Mockito.spy(new ContextKnowledge());
+        Mockito.when(this.ckf.create()).thenReturn(context);
+    }
+    
+    @Test
+    public void testContextKnowledge() throws IOException {
+        createDaos();
+        JSONEntityDecoder geomDec = Mockito.mock(JSONEntityDecoder.class);
+        MeasurementDecoder measDec = new MeasurementDecoder(geomDec, phenonmenonDao, sensorDao);
+        measDec.setEntityFactory(ef);
+        measDec.setDateTimeFormat(dtf);
+        
+        TrackDecoder trackDec = new TrackDecoder(measDec, sensorDao, measurementsDao, ckf);
+        trackDec.setEntityFactory(ef);
+        
+        JsonNode node = new ObjectMapper().readTree(getClass().getResourceAsStream("track-context-test.json"));
+        trackDec.decode(node, MediaType.APPLICATION_JSON_TYPE);
+        
+        Mockito.verify(context, Mockito.times(1)).get(JSONConstants.SENSOR_KEY);
+        Mockito.verify(context, Mockito.times(1)).get(JSONConstants.PHENOMENONS_KEY);
+    }
+
+    private void createDaos() {
+        this.sensorDao = Mockito.mock(SensorDao.class);
+        this.measurementsDao = Mockito.mock(MeasurementDao.class);
+        this.phenonmenonDao = Mockito.mock(PhenomenonDao.class);
+        Mockito.when(phenonmenonDao.getByName(Mockito.any(String.class))).thenReturn(Mockito.mock(LocalPhenomenon.class));
+    }
+    
+    public abstract class LocalPhenomenon implements Phenomenon {
+        
+    }
+    
+}

--- a/rest/src/test/resources/org/envirocar/server/rest/decoding/json/track-context-test.json
+++ b/rest/src/test/resources/org/envirocar/server/rest/decoding/json/track-context-test.json
@@ -1,0 +1,65 @@
+{
+   "type":"FeatureCollection",
+   "properties":{
+      "id":"52600faee4b000fe058019bb",
+      "sensor":{
+         "type":"car",
+         "properties":{
+            "id":"525eab3ce4b000fe057f084d",
+            "model":"Cee'd",
+            "fuelType":"diesel",
+            "manufacturer":"Kia",
+            "constructionYear":2010,
+            "engineDisplacement":1600
+         }
+      },
+	"appVersion": "Version 0.9.0-SNAPSHOT (21), 11.11.13 14:48",
+	"obdDevice": "DRIVEDECK BT OBD W4",
+	"touVersion": "2013-10-01",
+	"length": 100.5
+   },
+   "features":[
+      {
+         "type":"Feature",
+         "geometry":{
+            "type":"Point",
+            "coordinates":[
+               11.11605461,
+               49.42544685
+            ]
+         },
+         "properties":{
+            "id":"52600faee4b000fe058019bd",
+            "time":"2013-10-17T16:22:10Z",
+            "sensor":"525eab3ce4b000fe057f084d",
+            "phenomenons":{
+               "Rpm":{
+                  "value":1318.0,
+                  "unit":"u/min"
+               }
+            }
+         }
+      },
+      {
+         "type":"Feature",
+         "geometry":{
+            "type":"Point",
+            "coordinates":[
+               11.2,
+               49.5
+            ]
+         },
+         "properties":{
+            "id":"52600faee4b000fe058019be",
+            "time":"2013-10-17T16:25:10Z",
+            "sensor":"525eab3ce4b000fe057f084d",
+            "phenomenons":{
+               "Rpm":{
+                  "value":1318.0,
+                  "unit":"u/min"
+               }
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Introducing a `ContextKnowledge` for decoding array-style JSON payload.

Motivation:
When uploading a track with lots of measurements, currently this happens:

* for each measurement
   * each phenomenon is retrieved from the DAO
   * the sensor is retrieved from the DAO

This results in a huge amount of single DAO queries. The `ContextKnowledge` object is filled automatically with these information, thus drastically reducing DAO access by in-memory caching.

@autermann does this make sense? (edit: some minimal performance comparisons say: yes)