### PR TITLE
Read-Only Mode

### DIFF
--- a/rest/src/main/java/org/envirocar/server/rest/guice/ApplicationPropertiesModule.java
+++ b/rest/src/main/java/org/envirocar/server/rest/guice/ApplicationPropertiesModule.java
@@ -1,0 +1,32 @@
+package org.envirocar.server.rest.guice;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * @author Christian Autermann
+ */
+public class ApplicationPropertiesModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        Properties properties = new Properties();
+
+        URL resource = getClass().getResource("/application.properties");
+
+        if (resource != null) {
+            try (InputStream stream = resource.openStream()) {
+                properties.load(stream);
+            } catch (IOException ex) {
+                throw new Error("Can not read application.properties", ex);
+            }
+        }
+
+        bind(Properties.class).toInstance(properties);
+    }
+
+}

--- a/rest/src/main/java/org/envirocar/server/rest/rights/AccessRightsImpl.java
+++ b/rest/src/main/java/org/envirocar/server/rest/rights/AccessRightsImpl.java
@@ -36,10 +36,10 @@ import org.envirocar.server.core.entities.User;
  */
 public class AccessRightsImpl extends AbstractAccessRights {
     public AccessRightsImpl() {
-        super();
     }
 
-    public AccessRightsImpl(User user, GroupService groupService,
+    public AccessRightsImpl(User user,
+                            GroupService groupService,
                             FriendService friendService) {
         super(user, groupService, friendService);
     }
@@ -489,5 +489,5 @@ public class AccessRightsImpl extends AbstractAccessRights {
     public boolean canDelete(Fueling f) {
         return isSelf(f.getUser());
     }
-    
+
 }

--- a/rest/src/main/java/org/envirocar/server/rest/rights/ReadOnlyRights.java
+++ b/rest/src/main/java/org/envirocar/server/rest/rights/ReadOnlyRights.java
@@ -1,0 +1,112 @@
+package org.envirocar.server.rest.rights;
+
+import org.envirocar.server.core.FriendService;
+import org.envirocar.server.core.GroupService;
+import org.envirocar.server.core.entities.Fueling;
+import org.envirocar.server.core.entities.Group;
+import org.envirocar.server.core.entities.Measurement;
+import org.envirocar.server.core.entities.Phenomenon;
+import org.envirocar.server.core.entities.Sensor;
+import org.envirocar.server.core.entities.Track;
+import org.envirocar.server.core.entities.User;
+
+/**
+ * TODO JavaDoc
+ *
+ * @author Christian Autermann
+ */
+public class ReadOnlyRights extends AccessRightsImpl {
+    public ReadOnlyRights() {
+    }
+
+    public ReadOnlyRights(User user,
+                          GroupService groupService,
+                          FriendService friendService) {
+        super(user, groupService, friendService);
+    }
+    @Override
+    public boolean canDelete(Fueling f) {
+        return false;
+    }
+
+    @Override
+    public boolean canDelete(Group group) {
+        return false;
+    }
+
+    @Override
+    public boolean canDelete(Measurement measurement) {
+        return false;
+    }
+
+    @Override
+    public boolean canDelete(Phenomenon phenomenon) {
+        return false;
+    }
+
+    @Override
+    public boolean canDelete(Sensor sensor) {
+        return false;
+    }
+
+    @Override
+    public boolean canDelete(Track track) {
+        return false;
+    }
+
+    @Override
+    public boolean canDelete(User user) {
+        return false;
+    }
+
+    @Override
+    public boolean canModify(Group group) {
+        return false;
+    }
+
+    @Override
+    public boolean canModify(Measurement measurement) {
+        return false;
+    }
+
+    @Override
+    public boolean canModify(Phenomenon phenomenon) {
+        return false;
+    }
+
+    @Override
+    public boolean canModify(Sensor sensor) {
+        return false;
+    }
+
+    @Override
+    public boolean canModify(Track track) {
+        return false;
+    }
+
+    @Override
+    public boolean canModify(User user) {
+        return false;
+    }
+
+    @Override
+    public boolean canFriend(User user, User friend) {
+        return false;
+    }
+
+    @Override
+    public boolean canJoinGroup(Group group) {
+        return false;
+    }
+
+    @Override
+    public boolean canLeaveGroup(Group group) {
+        return false;
+    }
+
+    @Override
+    public boolean canUnfriend(User user, User friend) {
+        return false;
+    }
+
+}

--- a/webapp/src/main/resources/application.properties
+++ b/webapp/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+enviroCar.readOnly=false


### PR DESCRIPTION
The server does not allow any modifications (throwing a `403 Forbidden`) if the property `enviroCar.readOnly` is set to `true` in `WEB-INF/classes/application.properties`. The file is not monitored, so the server has to be restarted/reloaded...

@EHJ-52n: You thought about something like this?
@matthesrieke: any other suggestions?
